### PR TITLE
Add destroy field if missing

### DIFF
--- a/jquery.nested_attributes.coffee
+++ b/jquery.nested_attributes.coffee
@@ -251,7 +251,7 @@ class NestedAttributes
       # First look for an existing _destroy field
       $destroyField = $item.find("input[name='#{destroyFieldName}']")
       # If it doesn't exist, create it
-      if !$destroyField
+      if $destroyField.length == 0
         $destroyField = $("<input type=\"hidden\" name=\"#{destroyFieldName}\" />")
         $item.append($destroyField)
       $destroyField.val(true).change()

--- a/jquery.nested_attributes.js
+++ b/jquery.nested_attributes.js
@@ -232,7 +232,7 @@ Homepage: https://github.com/patbenatar/jquery-nested_attributes
         attributePosition = otherFieldName.lastIndexOf('[');
         destroyFieldName = "" + (otherFieldName.substring(0, attributePosition)) + "[_destroy]";
         $destroyField = $item.find("input[name='" + destroyFieldName + "']");
-        if (!$destroyField) {
+        if ($destroyField.length === 0) {
           $destroyField = $("<input type=\"hidden\" name=\"" + destroyFieldName + "\" />");
           $item.append($destroyField);
         }


### PR DESCRIPTION
- Doesn't add a blank item row if none visible after deletion until after beforeCallback returns (and deletion is confirmed)
- Only add a _destroy field on delete if it doesn't exist
